### PR TITLE
Add Kubernetes Support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,2 +1,3 @@
 scrapeIntervalSeconds: 15
 port: 9030
+kubernetes: false

--- a/config/config.go
+++ b/config/config.go
@@ -4,4 +4,5 @@ package config
 type Configurations struct {
 	ScrapeIntervalSeconds int64
 	Port                  int
+	Kubernetes            bool			 
 }

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,7 @@ github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/main.go
+++ b/main.go
@@ -125,7 +125,6 @@ func main() {
 	for _, info := range infos {
 		labels := BuildLabels(info.ID, false)
 		for labelName, _ := range labels {
-			log.Println(labelName)
 			labelNamesM[labelName] = ""
 		}
 	}
@@ -408,8 +407,9 @@ func BuildLabels(id string, filter bool) prometheus.Labels {
 		labels = prometheus.Labels{"id": "/docker/" + id, "image": info.Config.Image, 
 		    "pod": info.Config.Labels["io.kubernetes.pod.name"], 
 		    "namespace": info.Config.Labels["io.kubernetes.pod.namespace"],
-		    "beta_kubernetes_io_os": "windows",
-		    "kubernetes_io_role": "node"}
+			"node_name": os.Getenv("NODE_NAME"),
+			"beta_kubernetes_io_os": "windows",
+			"kubernetes_io_role": "node"}
 	} else {
 		labels = prometheus.Labels{"id": "/docker/" + id, "image": info.Config.Image, "name": info.Name}
 		for labelName, labelValue := range info.Config.Labels {

--- a/main.go
+++ b/main.go
@@ -407,7 +407,7 @@ func BuildLabels(id string, filter bool) prometheus.Labels {
 		labels = prometheus.Labels{"id": "/docker/" + id, "image": info.Config.Image, 
 		    "pod": info.Config.Labels["io.kubernetes.pod.name"], 
 		    "namespace": info.Config.Labels["io.kubernetes.pod.namespace"],
-			"node_name": os.Getenv("NODE_NAME"),
+			"kubernetes_io_hostname": os.Getenv("NODE_NAME"),
 			"beta_kubernetes_io_os": "windows",
 			"kubernetes_io_role": "node"}
 	} else {


### PR DESCRIPTION
Tested and working.

`Kubernetes: true` can be set in the config.yaml

`kubectl top pods` (along with HPA) but to get `kubectl top no` working, some recording rules are needed in prometheus (assuming you're using the metrics adaptor):

```
  recording_rules.yml: |
    groups:
    - name: windows-cpu-recording.rules
      rules:
      - record: container_cpu_usage_seconds_total 
        expr: sum without (kubernetes_node,app,component,core,kubernetes_name,mode,kubernetes_namespace) (label_replace(wmi_cpu_time_total{mode!="idle"}, "instance", "$1", "kubernetes_node", "(.*)"))
        labels:
          id: '/'
    - name: windows-memory-recording.rules
      rules:
      - record: container_memory_working_set_bytes 
        expr: sum without (component,release,job,app,kubernetes_name, kubernetes_node) (label_replace(wmi_cs_physical_memory_bytes-wmi_os_physical_memory_free_bytes, "instance", "$1", "kubernetes_node", "(.*)"))
        labels:
          id: '/'
```

Also requires `NODE_NAME` to be set as an env var via the downward API